### PR TITLE
feature: replace nested variables

### DIFF
--- a/lib/apress/variables.rb
+++ b/lib/apress/variables.rb
@@ -4,3 +4,10 @@ require 'apress/variables/version'
 require 'apress/variables/variable'
 require 'apress/variables/list'
 require 'apress/variables/parser'
+
+module Apress
+  module Variables
+    class Error < StandardError; end
+    class UnknownVariableError < Error; end
+  end
+end

--- a/lib/apress/variables/parser.rb
+++ b/lib/apress/variables/parser.rb
@@ -10,9 +10,19 @@ module Apress
     #   => 'text 1234124 text'
     class Parser
       attr_accessor :variables_list
+      attr_accessor :options
 
-      def initialize(variables_list)
+      # Public: Конструктор.
+      #
+      # variables_list - Apress::Variables::List - список переменных.
+      # options  - Hash, хеш опций:
+      #            :silent - boolean - не генерировать исключение при неизвестной переменной
+      #                                По умолчанию: true.
+      # Returns Parser.
+      #
+      def initialize(variables_list, options = {})
         @variables_list = variables_list
+        @options = options.reverse_merge!(:silent => true)
       end
 
       # Public: Заменяет переменные в шаблоне подсказки на соответствующие значения.
@@ -20,20 +30,49 @@ module Apress
       # template - String, шаблон для замены.
       # params   - Hash, хеш параметров необходимых для расчета переменных.
       #
-      # * Заменяет переменные вида {variable(args)}, аргументов может не быть.
+      # Заменяет переменные вида {variable(args)}, аргументов может не быть.
+      # Заменяет вложенные переменные {variable1({variable2(args)})}
+      #
+      # Если переменная на найдена в списке, то генерирует исключение UnknownVariableError, если не silent.
       #
       # Returns String.
       #
       def replace_variables(template, params)
+        begin
+          result = internal_replace(template.dup, params)
+        rescue UnknownVariableError
+          raise unless silent?
+          result = template
+        end
+
+        result.try(:html_safe)
+      end
+
+      private
+
+      def internal_replace(template, params)
         return if template.nil?
-        template.gsub(/(\{(.+?)(\((.+?)\))?\})/) do
-          if (var = variables_list.find_by_id($2)).present?
-            args = $4.to_s.split(',').map(&:strip)
+
+        # рекурсивно вычисляет переменные в выражении, начиная от самого глубоко-вложенного
+        template.gsub!(/\{(?<sub_expression>.+)(\(.+\))?\}/) do
+          "{#{internal_replace($~[:sub_expression], params)}}"
+        end
+
+        # заменяет конкретную простую переменную на значение
+        template.gsub!(/\{(?<var>.+?)(\((?<args>.+)\))?\}/) do
+          if (var = variables_list.find_by_id($~[:var])).present?
+            args = $~[:args].to_s.split(',').map(&:strip)
             var.value(params, args)
           else
-            $1
+            raise UnknownVariableError, "Variable #{$~[:var]} not found in list"
           end
-        end.try(:html_safe)
+        end
+
+        template
+      end
+
+      def silent?
+        options.fetch(:silent)
       end
     end
   end

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -24,29 +24,83 @@ describe Apress::Variables::Parser do
     end
   end
 
+  let(:var3) do
+    Apress::Variables::Variable.new.tap do |v|
+      v.id = :var3
+      v.source_proc = ->(params, args) { "var3_#{args.join}" }
+    end
+  end
+
   let(:list) { Apress::Variables::List.new }
   let(:company_id) { rand(234) }
-  let(:parser) { described_class.new(list) }
+  let(:options) { {} }
+  let(:parser) { described_class.new(list, options) }
   let(:args) { [1, 4, 's', 5, 6] }
 
   before do
     list.add(var0)
     list.add(var1)
     list.add(var2)
-  end
-
-  it "unknown variable is not replace" do
-    expect(parser.replace_variables("content {unknown_var} test", company_id: company_id))
-      .to eq "content {unknown_var} test"
+    list.add(var3)
   end
 
   it "several variables" do
-    expect(parser.replace_variables("content {int_variable} test {variable1} {unknown_var} a", company_id: company_id))
-      .to eq "content #{0} test a#{company_id}b {unknown_var} a"
+    expect(parser.replace_variables("content {int_variable} test {variable1} a", company_id: company_id))
+      .to eq "content #{0} test a#{company_id}b a"
   end
 
   it "variable with args" do
     expect(parser.replace_variables("content {variable_with_args(#{args.join(', ')})} test", company_id: company_id))
       .to eq "content #{company_id}#{args.join('_')} test"
+  end
+
+  it "variable with args" do
+    expect(parser.replace_variables(
+                   "content {var3({variable_with_args(#{args.join(', ')})})} test",
+                   company_id: company_id
+    ))
+    .to eq "content var3_#{company_id}#{args.join('_')} test"
+  end
+
+  it "nested variable without args" do
+    expect(parser.replace_variables("content {var3({variable1})} test", company_id: company_id))
+    .to eq "content var3_a#{company_id}b test"
+  end
+
+  it "nested variable with args" do
+    expect(parser.replace_variables(
+                   "content {var3({variable_with_args(#{args.join(', ')})}sometext)} test",
+                   company_id: company_id
+    ))
+    .to eq "content var3_#{company_id}#{args.join('_')}sometext test"
+  end
+
+  it "nested variable without args" do
+    expect(parser.replace_variables("content {var3({variable1})} test", company_id: company_id))
+    .to eq "content var3_a#{company_id}b test"
+  end
+
+  context "when unknown variable" do
+    context "when silent = true (default)" do
+      it "nothing replaced. returns the original string" do
+        expect(parser.replace_variables("content {int_variable} {unknown_var} test", company_id: company_id))
+        .to eq "content {int_variable} {unknown_var} test"
+      end
+
+      it "nothing replaced. returns the original string" do
+        expect(parser.replace_variables("content {var3({variable11})} test", company_id: company_id))
+        .to eq "content {var3({variable11})} test"
+      end
+    end
+
+    context "when silent = false" do
+      let(:options) { {silent: false} }
+
+      it "nothing replaced. raise UnknownVariableError" do
+        expect do
+          parser.replace_variables("content {int_variable} {unknown_var} test", company_id: company_id)
+        end.to raise_error Apress::Variables::UnknownVariableError
+      end
+    end
   end
 end


### PR DESCRIPTION
добавил возможность расчета вложенных переменных, вида:

`{variable1({variable2} some text)}`
результат вычисления `{variable2}` будет сконкатенирован с `some text` и передан как параметр при расчете переменной `variable1`

это необходимо, например, для создания универсального регионо-зависимого редиректа с авторизацией на каталог на портале.

т.е. будет как-то так:
`{redirect_to_with_auth(http://{region}.pulscen.ru/predl)}`
