### PR TITLE
feature: добавить возможность указать с source_class имя класса

### DIFF
--- a/lib/apress/variables/variable.rb
+++ b/lib/apress/variables/variable.rb
@@ -60,9 +60,9 @@ module Apress
       # Raises ArgumentError если переменная имеет не корректные свойства.
       #
       def value(params, args = [])
-        if source_class.present?
+        if data_source_class.present?
           params = source_params.merge(:object => params)
-          source_class.value_as_string(params)
+          data_source_class.value_as_string(params)
         elsif source_proc.present?
           proc_value(source_proc, params, args)
         else
@@ -142,6 +142,11 @@ module Apress
 
       alias_method_chain :value, :rate
       alias_method_chain :value, :formatting
+
+      def data_source_class
+        @data_source_class ||=
+          source_class.is_a?(String) ? source_class.constantize : source_class
+      end
     end
   end
 end

--- a/spec/lib/variables_spec.rb
+++ b/spec/lib/variables_spec.rb
@@ -85,18 +85,36 @@ describe Apress::Variables::Variable do
     let(:args) { [1, '2', 3] }
 
     context "when source_class specified" do
-      let(:source_class) { TestSource }
       let(:source_params) { {:field => 'field_name'} }
 
-      it "invokes the source, if source class specified" do
-        expect(TestSource).to receive(:value_as_string).
-                                with(:field => 'field_name', :object => params).
-                                and_call_original
-        expect(variable.value(params, args)).to eq "test_source_field_name_#{company_id}"
+      context 'when source type is Class instance' do
+        let(:source_class) { TestSource }
+
+        it "invokes the source, if source class specified" do
+          expect(TestSource).to(
+            receive(:value_as_string)
+            .with(field: 'field_name', object: params)
+            .and_call_original
+          )
+          expect(variable.value(params, args)).to eq "test_source_field_name_#{company_id}"
+        end
+
+        it "args not reguired argument" do
+          expect(variable.value(params)).to eq "test_source_field_name_#{company_id}"
+        end
       end
 
-      it "args not reguired argument" do
-        expect(variable.value(params)).to eq "test_source_field_name_#{company_id}"
+      context 'when source type is String instance' do
+        let(:source_class) { 'TestSource' }
+
+        it "invokes the source, if source class specified" do
+          expect(TestSource).to(
+            receive(:value_as_string)
+            .with(field: 'field_name', object: params)
+            .and_call_original
+          )
+          expect(variable.value(params, args)).to eq "test_source_field_name_#{company_id}"
+        end
       end
     end
 


### PR DESCRIPTION
https://jira.railsc.ru/browse/ORDERS-499

Проблема в том, что я вынес переменые в гем https://github.com/abak-press/apress-orders/pull/766, а они ссылаются на классы источников данных, которые еще в гем не вынесены и при инициализации в проекте все падает (точнее в тестах плагинов)

Поэтому я хочу добавить возможность отложенного вычисления классов-источников тут fix: отложенное вычисление классов-источников для переменных

Тогда тут все взлетит https://github.com/abak-press/blizko/pull/9747