### PR TITLE
fix: match variable by most matching context

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,30 +1,22 @@
-matrix:
-  include:
-    - DOCKER_RUBY_VERSION: 2.2
-      RUBY_IMAGE_TAG: 2.2-1
-
-    - DOCKER_RUBY_VERSION: 1.9.3
-      RUBY_IMAGE_TAG: 1.9.3-2
-
 build:
-  image: abakpress/dind:2
-  privileged: true
-  volumes:
-    - /home/data/drone/images:/images
-    - /home/data/drone/gems:/bundle
-    - /home/data/drone/key_cache:/ssh_keys
-  environment:
-    - COMPOSE_FILE_EXT=drone
-    - RAILS_ENV=test
-  commands:
-    - wrapdocker docker -v
+  test:
+    image: abakpress/dind-testing
+    privileged: true
+    volumes:
+      - /home/data/drone/images:/images
+      - /home/data/drone/gems:/bundle
+      - /home/data/drone/key_cache:/ssh_keys
+    environment:
+      - COMPOSE_FILE_EXT=drone
+      - RUBY_IMAGE_TAG=2.2-latest
+      - RAILS_ENV=test
+    commands:
+      - wrapdocker docker -v
 
-    - if [ ! -e /images/ssh-agent.tar ]; then docker pull whilp/ssh-agent; docker save whilp/ssh-agent > /images/ssh-agent.tar; fi
-    - if [ ! -e /images/ruby_$RUBY_IMAGE_TAG.tar ]; then docker pull abakpress/ruby:$RUBY_IMAGE_TAG; docker save abakpress/ruby:$RUBY_IMAGE_TAG > /images/ruby_$RUBY_IMAGE_TAG.tar; fi
+      - fetch-images
+        --image whilp/ssh-agent
+        --image abakpress/ruby-app:$RUBY_IMAGE_TAG
 
-    - docker load -i /images/ssh-agent.tar
-    - docker load -i /images/ruby_$RUBY_IMAGE_TAG.tar
-
-    - dip ssh add -T -v /ssh_keys -k /ssh_keys/id_rsa
-    - dip provision
-    - dip rspec
+      - dip ssh add -T -v /ssh_keys -k /ssh_keys/id_rsa
+      - dip provision
+      - dip rspec

--- a/dip.yml
+++ b/dip.yml
@@ -1,8 +1,8 @@
 version: '1'
 
 environment:
-  DOCKER_RUBY_VERSION: 1.9.3
-  RUBY_IMAGE_TAG: 1.9.3-2
+  DOCKER_RUBY_VERSION: 2.2
+  RUBY_IMAGE_TAG: 2.2-latest
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test
   APRESS_GEMS_CREDENTIALS: ""
@@ -43,7 +43,6 @@ interaction:
 provision:
   - docker volume create --name bundler_data
   - dip bundle config --local https://gems.railsc.ru/ ${APRESS_GEMS_CREDENTIALS}
+  - dip clean
   - dip bundle install
-  - dip sh mkdir -p gemfiles/.bundle
-  - dip sh ln -sf ../../.bundle/config /app/gemfiles/.bundle/config
   - dip appraisal install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: abakpress/ruby:$RUBY_IMAGE_TAG
+    image: abakpress/ruby-app:$RUBY_IMAGE_TAG
     environment:
       - BUNDLE_PATH=/bundle/$DOCKER_RUBY_VERSION
       - SSH_AUTH_SOCK=/ssh/auth/sock

--- a/lib/apress/variables/list.rb
+++ b/lib/apress/variables/list.rb
@@ -51,9 +51,14 @@ module Apress
       def for_context(context)
         context_set = key_for_context(context)
 
-        result = @storage.flat_map do |key, list|
+        sorted_keys = @storage
+          .keys
+          .sort { |key| key.intersection(context_set).count }
+          .reverse!
+        result = sorted_keys.map do |key|
+          list =  @storage[key]
           list.values if key.subset?(context_set)
-        end
+        end.flatten!
 
         self.class.new(result.compact)
       end

--- a/spec/lib/list_spec.rb
+++ b/spec/lib/list_spec.rb
@@ -101,8 +101,8 @@ describe Apress::Variables::List do
 
     it { expect(list.for_context(['user_id'])).to be_a(described_class) }
 
-    it { expect(list.for_context(['user_id']).to_a).to eq [var0, var1] }
-    it { expect(list.for_context([:user_id]).to_a).to eq [var0, var1] }
+    it { expect(list.for_context(['user_id']).to_a).to eq [var1, var0] }
+    it { expect(list.for_context([:user_id]).to_a).to eq [var1, var0] }
     it { expect(list.for_context([:user_id, 'company_id']).to_a).to match_array([var0, var1, var2, var3, var4]) }
     it do
       expect(list.for_context([:unknown_param, :user_id, 'company_id']).to_a).
@@ -111,9 +111,9 @@ describe Apress::Variables::List do
 
     it { expect(list.for_context([:unknown_param]).to_a).to eq [var0] }
 
-    it { expect(list.for_context(['company_id']).to_a).to eq [var0, var4] }
+    it { expect(list.for_context(['company_id']).to_a).to eq [var4, var0] }
 
-    it { expect(list.for_context(:company_id => 1).to_a).to eq [var0, var4] }
+    it { expect(list.for_context(:company_id => 1).to_a).to eq [var4, var0] }
   end
 
   context "#redirects" do


### PR DESCRIPTION
[WIP]

Проблема, что когда есть переменные с одинаковыми именами, то выбирается первая в подходящем контексте, к примеру, `user:auth_redirect`

```ruby
  context :view_context, :company_id, :user_id

  variable do
    id            'user:auth_redirect'
  end
```

должно быть раньше чем
```ruby
  context :view_context, :user_id

  variable do
    id            'user:auth_redirect'
  end
```
Точнее компанейский контекст должен быть объявлен раньше пользовательского, что не очень верно.
При выносе в гем порядок инициализации контекстов контролировать практически невозможно. И так получилось, что впервые переменные определяются (пока) тут https://github.com/abak-press/apress-orders/blob/pc-release/lib/apress/orders/engine.rb#L297 и нарушается правильный (правда про него не все знают) порядок определения контекстов

Предлагается сортировать контексты по уменьшению количества пересечений что даст гарантию того, что переменная из более подходящего контекста будет выбрана 